### PR TITLE
Update virgo.h

### DIFF
--- a/virgo.h
+++ b/virgo.h
@@ -30,6 +30,7 @@ SOFTWARE.
 #include <vector>
 #include <regex>
 #include <iostream>
+#include <map>
 
 #define ENCODE_MOVE(from, to, type) (0x0000u | (from) | ((to) << 6) | ((type) << 12))
 #define MOVE_FROM(move) ((move) & 0x3f)


### PR DESCRIPTION
std::map header added. But that problem with the position of the king and queen being reversed still exists.

For example, if you run this code you will be able to check this:

```
#include <vector>
#include <string>
#include <map>
#include <iostream>

#define VIRGO_IMPLEMENTATION
#include "virgo.h"


using namespace std;
int main(){
	
	/*
	typedef enum Piece {
        PAWN,
        ROOK,
        KNIGHT,
        BISHOP,
        KING,
        QUEEN,
        EMPTY
        } Piece;
	*/
	
	virgo::Chessboard board;
	std::vector<std::string> pieces = {"pawn", "rook", "knight", "bishop", "king", "queen", "empty"};
	
	
	
	cout << board << endl;
	
	cout << "e1: " << pieces[board[virgo::e1].first] << endl;
	cout << "d1: " << pieces[board[virgo::d1].first] << endl;
	
}
```

```
Output:

A   B   C   D   E   F   G   H
    +---+---+---+---+---+---+---+---+
8   | r | n | b | k | q | b | n | r |   8
    +---+---+---+---+---+---+---+---+
7   | p | p | p | p | p | p | p | p |   7
    +---+---+---+---+---+---+---+---+
6   |   |   |   |   |   |   |   |   |   6
    +---+---+---+---+---+---+---+---+
5   |   |   |   |   |   |   |   |   |   5
    +---+---+---+---+---+---+---+---+
4   |   |   |   |   |   |   |   |   |   4
    +---+---+---+---+---+---+---+---+
3   |   |   |   |   |   |   |   |   |   3
    +---+---+---+---+---+---+---+---+
2   | P | P | P | P | P | P | P | P |   2
    +---+---+---+---+---+---+---+---+
1   | R | N | B | K | Q | B | N | R |   1
    +---+---+---+---+---+---+---+---+
      A   B   C   D   E   F   G   H

e1: queen
d1: king

[Program finished]
```
